### PR TITLE
修改依赖包@kube-design/components中的颜色样式,并使用patch-package包记录

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "test:e2e": "cypress run",
     "serve": "NODE_ENV=production node server/server.js",
     "lint": "eslint src/**/*.jsx src/**/*.js",
-    "postinstall": "rimraf node_modules/.cache",
+    "postinstall": "patch-package && rimraf node_modules/.cache",
     "prebuild": "rimraf dist",
     "release": "standard-version"
   },
@@ -154,6 +154,7 @@
     "node-sass": "^4.13.1",
     "nodemon": "^1.15.1",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
+    "patch-package": "^6.4.7",
     "postcss-flexbugs-fixes": "3.2.0",
     "postcss-loader": "^3.0.0",
     "prettier": "^1.14.2",

--- a/patches/@kube-design+components+1.1.19.patch
+++ b/patches/@kube-design+components+1.1.19.patch
@@ -1,0 +1,108 @@
+diff --git a/node_modules/@kube-design/components/esm/styles/variables.scss b/node_modules/@kube-design/components/esm/styles/variables.scss
+index 3adb2c3..6f9018a 100644
+--- a/node_modules/@kube-design/components/esm/styles/variables.scss
++++ b/node_modules/@kube-design/components/esm/styles/variables.scss
+@@ -20,10 +20,11 @@ $green-color03: #55bc8a;
+ $green-color04: #479e88;
+ $green-color05: #3b747a;
+ $blue-color01: #c7deef;
+-$blue-color02: #7eb8dc;
++$blue-color02: #80caf9;
+ $blue-color03: #329dce;
+ $blue-color04: #3385b0;
+-$blue-color05: #326e93;
++$blue-color05: #1890ff;
++$blue-color06: #005faf;
+ $red-color01: #fae7e5;
+ $red-color02: #ea8573;
+ $red-color03: #ca2621;
+@@ -52,7 +53,7 @@ $warning: $yellow-color03;
+ $error: $red-color03;
+ $info: $blue-color03;
+ 
+-$primary: $green-color03;
++$primary: $blue-color05;
+ 
+ $border-radius: 4px;
+ 
+@@ -104,9 +105,9 @@ $btn-default-active-border: $light-color07;
+ $btn-default-shadow: none;
+ $btn-default-active-shadow: inset 0 4px 8px 0 rgba(36, 46, 66, 0.12);
+ 
+-$btn-primary-bg: $green-color03;
++$btn-primary-bg: $primary;
+ $btn-primary-text-color: $white;
+-$btn-primary-shadow: 0 8px 16px 0 rgba(85, 188, 138, 0.36);
++$btn-primary-shadow: 0 8px 16px 0 rgba(100, 149, 237, 0.2);
+ $btn-primary-active-shadow: inset 0 4px 8px 0 rgba(35, 45, 65, 0.24);
+ 
+ $btn-control-bg: $dark-color07;
+@@ -154,12 +155,12 @@ $input-default-width: 376px;
+ $input-bg-color: $white;
+ $input-border-color: $light-color08;
+ $input-hover-color: $dark-color01;
+-$input-focus-color: $green-color03;
++$input-focus-color: $primary;
+ $input-error-color: $red-color03;
+ $input-caret-color: $dark-color06;
+ $input-placeholder-color: $dark-color03;
+ $input-disabled-color: $light-color02;
+-$input-focus-shadow: 0 4px 8px 0 rgba(85,188,138,.2);
++$input-focus-shadow: 0 4px 8px 0 rgba(100, 149, 237, 0.2);
+ 
+ $input-search-bg: $bg-color;
+ $input-search-hover-bg: $white;
+diff --git a/node_modules/@kube-design/components/lib/styles/variables.scss b/node_modules/@kube-design/components/lib/styles/variables.scss
+index 3adb2c3..6f9018a 100644
+--- a/node_modules/@kube-design/components/lib/styles/variables.scss
++++ b/node_modules/@kube-design/components/lib/styles/variables.scss
+@@ -20,10 +20,11 @@ $green-color03: #55bc8a;
+ $green-color04: #479e88;
+ $green-color05: #3b747a;
+ $blue-color01: #c7deef;
+-$blue-color02: #7eb8dc;
++$blue-color02: #80caf9;
+ $blue-color03: #329dce;
+ $blue-color04: #3385b0;
+-$blue-color05: #326e93;
++$blue-color05: #1890ff;
++$blue-color06: #005faf;
+ $red-color01: #fae7e5;
+ $red-color02: #ea8573;
+ $red-color03: #ca2621;
+@@ -52,7 +53,7 @@ $warning: $yellow-color03;
+ $error: $red-color03;
+ $info: $blue-color03;
+ 
+-$primary: $green-color03;
++$primary: $blue-color05;
+ 
+ $border-radius: 4px;
+ 
+@@ -104,9 +105,9 @@ $btn-default-active-border: $light-color07;
+ $btn-default-shadow: none;
+ $btn-default-active-shadow: inset 0 4px 8px 0 rgba(36, 46, 66, 0.12);
+ 
+-$btn-primary-bg: $green-color03;
++$btn-primary-bg: $primary;
+ $btn-primary-text-color: $white;
+-$btn-primary-shadow: 0 8px 16px 0 rgba(85, 188, 138, 0.36);
++$btn-primary-shadow: 0 8px 16px 0 rgba(100, 149, 237, 0.2);
+ $btn-primary-active-shadow: inset 0 4px 8px 0 rgba(35, 45, 65, 0.24);
+ 
+ $btn-control-bg: $dark-color07;
+@@ -154,12 +155,12 @@ $input-default-width: 376px;
+ $input-bg-color: $white;
+ $input-border-color: $light-color08;
+ $input-hover-color: $dark-color01;
+-$input-focus-color: $green-color03;
++$input-focus-color: $primary;
+ $input-error-color: $red-color03;
+ $input-caret-color: $dark-color06;
+ $input-placeholder-color: $dark-color03;
+ $input-disabled-color: $light-color02;
+-$input-focus-shadow: 0 4px 8px 0 rgba(85,188,138,.2);
++$input-focus-shadow: 0 4px 8px 0 rgba(100, 149, 237, 0.2);
+ 
+ $input-search-bg: $bg-color;
+ $input-search-hover-bg: $white;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1515,6 +1515,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npm.taobao.org/@yarnpkg/lockfile/download/@yarnpkg/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha1-53qX+9NFt22DJF7c0X05OxtB+zE=
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -2421,7 +2426,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -5580,6 +5585,13 @@ find-versions@^3.2.0:
   dependencies:
     semver-regex "^2.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npm.taobao.org/find-yarn-workspace-root/download/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha1-9H+40jnJAOt4F5qoG2ZnPqyI970=
+  dependencies:
+    micromatch "^4.0.2"
+
 findup-sync@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
@@ -5697,6 +5709,15 @@ fs-extra@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
   integrity sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.nlark.com/fs-extra/download/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -6905,6 +6926,11 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
+is-docker@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.nlark.com/is-docker/download/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -7218,6 +7244,13 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is-wsl@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.nlark.com/is-wsl/download/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -7969,6 +8002,13 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.nlark.com/klaw-sync/download/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha1-H9LP1W67YlAYERTwpYEWcJnCsow=
+  dependencies:
+    graceful-fs "^4.1.11"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -8885,6 +8925,14 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+micromatch@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.npm.taobao.org/micromatch/download/micromatch-4.0.4.tgz?cache=0&sync_timestamp=1618054841521&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmicromatch%2Fdownload%2Fmicromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.2.3"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -9642,6 +9690,14 @@ only@~0.0.2:
   resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
   integrity sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.npmmirror.com/open/download/open-7.4.2.tgz?cache=0&sync_timestamp=1635048361939&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fopen%2Fdownload%2Fopen-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha1-uBR+Jtzz5CYxbHMAif1x7dKcIyE=
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opencollective-postinstall@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
@@ -9718,7 +9774,7 @@ os-homedir@^1.0.0, os-homedir@^1.0.1:
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
-os-tmpdir@^1.0.0:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -9934,6 +9990,25 @@ passthrough-counter@^1.0.0:
   resolved "https://registry.yarnpkg.com/passthrough-counter/-/passthrough-counter-1.0.0.tgz#1967d9e66da572b5c023c787db112a387ab166fa"
   integrity sha1-GWfZ5m2lcrXAI8eH2xEqOHqxZvo=
 
+patch-package@^6.4.7:
+  version "6.4.7"
+  resolved "https://registry.npm.taobao.org/patch-package/download/patch-package-6.4.7.tgz#2282d53c397909a0d9ef92dae3fdeb558382b148"
+  integrity sha1-IoLVPDl5CaDZ75La4/3rVYOCsUg=
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+
 path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
@@ -10056,6 +10131,11 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+picomatch@^2.2.3:
+  version "2.3.0"
+  resolved "https://registry.nlark.com/picomatch/download/picomatch-2.3.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fpicomatch%2Fdownload%2Fpicomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
+  integrity sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=
 
 pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
@@ -12863,6 +12943,13 @@ tmp@0.1.0:
   integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
   dependencies:
     rimraf "^2.6.3"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.npm.taobao.org/tmp/download/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
**What type of PR is this?**
修改样式

**What this PR does / why we need it**:
这个Pull Request修复了页面中大量hover、active的元素颜色仍为绿色的bug

**Special notes for reviewers**:
这个PR内的代码已经在本人的开发环境调试成功，但由于引入了新的依赖项，请先测试后再合并
运行前需要重新执行`yarn`命令
```bash
# 拉取分支
git checkout -b test-v1.0
git pull origin hzy-ui-v1.7
# 同步改动
yarn
```

**Additional documentation, usage docs, etc.**:
```docs
一些效果图片
```

<img width="1440" alt="Pic. 1" src="https://user-images.githubusercontent.com/49408466/145718088-a572cc08-2b1b-4ed7-b059-167f496d995d.png">

<img width="672" alt="截屏2021-12-12 下午11 16 47" src="https://user-images.githubusercontent.com/49408466/145718139-811301a6-72fa-4a58-adf0-129c3f3aba38.png">

<img width="1164" alt="截屏2021-12-12 下午11 17 40" src="https://user-images.githubusercontent.com/49408466/145718171-c8761cf3-fe4b-4b73-916f-1d26177c9d46.png">
